### PR TITLE
Fix for highlighting in repeated elements

### DIFF
--- a/polito-codehilite.html
+++ b/polito-codehilite.html
@@ -25,8 +25,8 @@
                     observer: "_linksChanged"
                 }
             },
-            ready: function() {
-                hljs.initHighlightingOnLoad();
+            attached: function() {
+                hljs.highlightBlock( this.$.codeContainer );
             },
             _linksChanged: function() {
                 if(!this.links) return;


### PR DESCRIPTION
When a polito-codehilite was inside a dom-repeat it wasn't highlighting.  This fixes it.
